### PR TITLE
fix: release-docs path issue

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -45,7 +45,7 @@ jobs:
           # Enable dotglob to copy hidden files (like .gitignore)
           shopt -s dotglob
           # Copy the build from the docs-docusaurus/build folder
-          cp -r documentation/build/* /tmp/temp-directory/
+          cp -r docs/build/* /tmp/temp-directory/
           shopt -u dotglob
           # Stash any changes to prevent checkout conflicts
           git stash push


### PR DESCRIPTION
## fix: release-docs path issue

fixed the path of release-doc file , changed the path from documentation to docs

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `npm run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.
- [ ] I have verified that my changes work in all supported environments (e.g., Chrome, Firefox, Safari).
